### PR TITLE
Adding a drawer to show submission details (if supplied from server)

### DIFF
--- a/src/globalStatusBar/lib/libTransition.js
+++ b/src/globalStatusBar/lib/libTransition.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React from 'react';
 import {Slide, Zoom, Collapse, Fade, Grow} from '@material-ui/core';
 
 const StandardTiming = {enter: 500, exit: 500};

--- a/src/globalStatusBar/login/loginDialog.js
+++ b/src/globalStatusBar/login/loginDialog.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import { DialogTitle, DialogContent, DialogContentText, Dialog, DialogActions, Grid } from '@material-ui/core';
-import { TextField, Button, Slide } from '@material-ui/core';
+import { TextField, Button } from '@material-ui/core';
 
 import {validateID, validateKey} from '../lib/libValidateLogin.js';
 

--- a/src/globalStatusBar/userSetting/passwordChange/passwordChangeDialog.js
+++ b/src/globalStatusBar/userSetting/passwordChange/passwordChangeDialog.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 
 import { DialogTitle, DialogContent, Dialog, DialogActions } from '@material-ui/core';
-import { Slide, Button, TextField } from '@material-ui/core'
+import { Button, TextField } from '@material-ui/core'
 import {fade} from '../../lib/libTransition.js';
 
 /**

--- a/src/globalStatusBar/userSetting/userSettingDialog.js
+++ b/src/globalStatusBar/userSetting/userSettingDialog.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 
 import { DialogTitle, DialogContent, Dialog, DialogActions, AppBar, Tabs, Tab } from '@material-ui/core';
-import { Button, Slide } from '@material-ui/core';
+import { Button } from '@material-ui/core';
 import PasswordChangeDialog from './passwordChange/passwordChangeDialog.js';
 import {fade} from '../lib/libTransition.js';
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,17 +3,32 @@ import ReactDOM from 'react-dom';
 import './index.css'
 import 'typeface-roboto';
 import * as serviceWorker from './serviceWorker';
+import { Button } from '@material-ui/core';
+
 import GlobalStatusBar from './globalStatusBar/globalStatusBar.js'
 import Sidenav from './sidenav/sidenav.js';
-import { Button } from '@material-ui/core';
+import SubmissionTable from './submissions/submissionTable.js';
+
+import SubmissionLauncher from './submissions/submissionLauncher.js';
 
 class Hestia extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            sidebarOpen : false
+            sidebarOpen : false,
+            currentPage : 'front'
         }
+        this.changePage = this.changePage.bind(this);
     }
+
+    changePage(to) {
+        this.setState({
+            currentPage: to,
+            sidebarOpen: false
+            // close after clicking
+        })
+    }
+
     render() {
         return (
             <>
@@ -25,8 +40,24 @@ class Hestia extends React.Component {
                 <Sidenav open={this.state.sidebarOpen} onClose={() => this.setState({
                     sidebarOpen: false
                 })} pages={[
-                    <Button onClick={() => alert(1)}>Alert (1)</Button>
+                    <Button onClick={() => this.changePage('front')}>Alert (1)</Button>,
+                    <SubmissionLauncher onClick={() => this.changePage('submissions')} button/>
                 ]} />
+                {this.state.currentPage === "submissions" && <>
+                    <SubmissionTable submissionList={[{
+                        contestant : 'minhducsun123456', problem : 'A',
+                        verdict : 'Accepted', executionTime: '00:00:123', memory : '1TB', submissionTimestamp: '00:00:00',
+                        language : 'Perl',
+                    },{
+                        contestant : 'minhducsun2002', problem : 'A',
+                        verdict : 'Wrong output', executionTime: '11:00:234', memory : '1TB', submissionTimestamp: '00:00:00',
+                        language : 'Pascal',
+                    },{
+                        contestant : 'minhducsun123456', problem : 'A',
+                        verdict : 'Accepted', executionTime: '38:46:115', memory : '1TB', submissionTimestamp: '00:00:00',
+                        language : 'C99',
+                    }]}/>
+                </>}
             </>
         )
     }

--- a/src/index.js
+++ b/src/index.js
@@ -46,15 +46,15 @@ class Hestia extends React.Component {
                 {this.state.currentPage === "submissions" && <>
                     <SubmissionTable submissionList={[{
                         contestant : 'minhducsun123456', problem : 'A',
-                        verdict : 'Accepted', executionTime: '00:00:123', memory : '1TB', submissionTimestamp: '00:00:00',
+                        verdict : 'Accepted', executionTime: '00:00:123', memory : '1TB', timestamp: '00:00:00',
                         language : 'Perl',
                     },{
                         contestant : 'minhducsun2002', problem : 'A',
-                        verdict : 'Wrong output', executionTime: '11:00:234', memory : '1TB', submissionTimestamp: '00:00:00',
+                        verdict : 'Wrong output', executionTime: '11:00:234', memory : '1TB', timestamp: '00:00:00',
                         language : 'Pascal',
                     },{
                         contestant : 'minhducsun123456', problem : 'A',
-                        verdict : 'Accepted', executionTime: '38:46:115', memory : '1TB', submissionTimestamp: '00:00:00',
+                        verdict : 'Accepted', executionTime: '38:46:115', memory : '1TB', timestamp: '00:00:00',
                         language : 'C99',
                     }]}/>
                 </>}

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,11 @@ class Hestia extends React.Component {
                     <SubmissionTable submissionList={[{
                         contestant : 'minhducsun123456', problem : 'A',
                         verdict : 'Accepted', executionTime: '00:00:123', memory : '1TB', timestamp: '00:00:00',
-                        language : 'Perl',
+                        language : 'Perl', tests : [
+                            {verdict : 'AC', executionTime : '1000h', memory : '1TB', mark : '30'},
+                            {verdict : 'AC', executionTime : '1000d', memory : '1MB', mark : '50'},
+                            {verdict : 'AC', executionTime : '0.1s', memory : '5TB', mark : '300'}
+                        ]
                     },{
                         contestant : 'minhducsun2002', problem : 'A',
                         verdict : 'Wrong output', executionTime: '11:00:234', memory : '1TB', timestamp: '00:00:00',
@@ -55,7 +59,9 @@ class Hestia extends React.Component {
                     },{
                         contestant : 'minhducsun123456', problem : 'A',
                         verdict : 'Accepted', executionTime: '38:46:115', memory : '1TB', timestamp: '00:00:00',
-                        language : 'C99',
+                        language : 'C99', tests : [
+                            {verdict : 'AC', executionTime : '5s', memory : '10TB', mark : '30'}
+                        ]
                     }]}/>
                 </>}
             </>

--- a/src/sidenav/sidenav.js
+++ b/src/sidenav/sidenav.js
@@ -10,8 +10,9 @@ import {Drawer, ListItem, List} from '@material-ui/core';
 class Sidenav extends Component {
     renderItems() {
         return this.props.pages.map(page => {
+            // mirroring onClick function 
             return (
-                <ListItem>
+                <ListItem onClick={page.props.onClick} button={page.props.button}>
                     {page}
                 </ListItem>
             )

--- a/src/submissions/signature/memorySignature.js
+++ b/src/submissions/signature/memorySignature.js
@@ -5,7 +5,7 @@ import Memory from '@material-ui/icons/Memory';
 /**
  * @name MemorySignature : Submission's memory consumption. FlexGrow. 
  *                       All props are passed down to <Typography>.
- * @param {String} memload : Memory consumption.
+ * @param {String} memory : Memory consumption.
  * @return {React.Component} : A <Typography> that shows the timestamp of current submission.
  *                             Children override if exist.
  * @author minhducsun2002
@@ -26,7 +26,7 @@ class MemorySignature extends Component {
                     <Typography variant='overline' color="inherit" style={{
                         flexGrow: 1, display: 'inline-block'
                     }} {...this.props}>
-                        {this.props.children ? this.props.children : this.props.memload}
+                        {this.props.children ? this.props.children : this.props.memory}
                     </Typography>
                 </Grid>
             </Grid>

--- a/src/submissions/signature/verdictIcons/exitErrorVerdictSignature.js
+++ b/src/submissions/signature/verdictIcons/exitErrorVerdictSignature.js
@@ -3,7 +3,7 @@ import Error from '@material-ui/icons/Error';
 
 /**
  * @name ExitErrorVerdictSignature
- * @desc 'Memory exhausted' verdict's icon, margin-and-color-calibrated
+ * @desc 'Error during runtime' verdict's icon, margin-and-color-calibrated
  * @returns {<Error />} An 'error' SVG icon 
  */
 

--- a/src/submissions/signature/verdictIcons/unknownVerdictSignature.js
+++ b/src/submissions/signature/verdictIcons/unknownVerdictSignature.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import HelpOutline from '@material-ui/icons/HelpOutline';
+
+/**
+ * @name UnknownVerdictSignature
+ * @desc 'Memory exhausted' verdict's icon, margin-and-color-calibrated
+ * @returns {<HelpOutline />} An 'help' SVG icon 
+ */
+
+class UnknownVerdictSignature extends React.Component {
+    render() {
+        return <HelpOutline style={{marginRight : 10, marginTop: -2.5, color: 'black'}}/>
+    }
+}
+
+export default UnknownVerdictSignature;

--- a/src/submissions/signature/verdictSignature.js
+++ b/src/submissions/signature/verdictSignature.js
@@ -5,12 +5,15 @@ import AcceptedVerdictIcon from './verdictIcons/acceptedVerdictSignature.js';
 import WrongVerdictIcon from './verdictIcons/wrongVerdictSignature.js';
 import TimeoutVerdictIcon from './verdictIcons/timeoutVerdictSignature.js';
 import MemExhaustedVerdictSignature from './verdictIcons/memExhaustVerdictSignature.js';
-import ExitErrorVerdictSignature from './verdictIcons/exitErrorVerdictSignature.js'
+import ExitErrorVerdictSignature from './verdictIcons/exitErrorVerdictSignature.js';
+import UnknownVerdictSignature from './verdictIcons/unknownVerdictSignature';
 
 /**
  * @name VerdictSignature : Submission's judged verdict. FlexGrow.
  *                          All props are passed down to <Typography>.
  * @param {String} verdict : Judged verdict.
+ * @param {Boolean} iconOnly : Whether to return icon only or with the verdict text.
+ * @param {Boolean} reversed : Whether the verdict text should appear before or after the icon.
  * @return {React.Component} : A <Typography> that shows the verdict.
  *                             Children override if exist.
  * @author minhducsun2002
@@ -26,11 +29,16 @@ const verdictIcon = {
 
     "TLE": <TimeoutVerdictIcon />,
     "Time limit violated" : <TimeoutVerdictIcon />,
+    "Time limit exceeded" : <TimeoutVerdictIcon />,
 
     "MLE": <MemExhaustedVerdictSignature />,
+    "Memory limit exceeded" : <MemExhaustedVerdictSignature />,
 
     "RE": <ExitErrorVerdictSignature />,
-    "RTE": <ExitErrorVerdictSignature />
+    "RTE": <ExitErrorVerdictSignature />,
+    "Runtime error" : <ExitErrorVerdictSignature />,
+
+    "unknown" : <UnknownVerdictSignature />
 }
 
 // CSS colour of verdicts
@@ -52,23 +60,40 @@ const color = {
 }
 
 class VerdictSignature extends Component {
-    render() {
-        return (
-            <Grid container spacing={0} alignItems="flex-start">
-                <Grid item>
-                    {verdictIcon[this.props.verdict]}
-                </Grid>
-                <Grid item>
-                    <Typography variant='body1' style={{
-                        flexGrow: 1,
-                        color: color[this.props.verdict],
-                        fontWeight : this.props.success ? 'bold' : ''
-                    }} {...this.props}>
-                        {this.props.children ? this.props.children : this.props.verdict}
-                    </Typography>
-                </Grid>
+    constructor(props) {
+        super(props);
+        // in order to allow reversion, we render HERE.
+        this.state = {
+            icon : <Grid item>
+                {this.props.verdict ? verdictIcon[this.props.verdict] : verdictIcon["unknown"]}
+            </Grid>,
+            verdictText : <Grid item>
+                <Typography variant='body1' style={{
+                    flexGrow: 1,
+                    color: color[this.props.verdict],
+                    fontWeight : this.props.success ? 'bold' : ''
+                }} {...this.props}>
+                    {this.props.children ? this.props.children : this.props.verdict}
+                </Typography>
             </Grid>
-        )
+        }
+    }
+    render() {
+        if (this.props.iconOnly)
+            return verdictIcon[this.props.verdict];
+        else
+            return (
+                <Grid container spacing={0} alignItems="flex-start">
+                    {this.props.reversed 
+                        ? <>
+                            {this.state.verdictText}
+                            {this.state.icon}
+                        </> : <>
+                            {this.state.icon}
+                            {this.state.verdictText}
+                        </>}
+                </Grid>
+            )
     }
 }
 

--- a/src/submissions/submission.js
+++ b/src/submissions/submission.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { TableRow, TableCell } from '@material-ui/core';
+
+import ContestantSignature from './signature/contestantSignature.js';
+import ProblemSignature from './signature/problemSignature.js';
+import LanguageSignature from './signature/languageSignature.js';
+import VerdictSignature from './signature/verdictSignature.js';
+import ExecTimeSignature from './signature/execTimeSignature.js';
+import TimestampSignature from './signature/timestampSignature.js';
+import MemorySignature from './signature/memorySignature.js';
+
+/**
+ * @name Submission
+ * @desc Render a submission table row
+ * @param {String} contestant : Contestant identifier
+ * @param {String} problem : Problem identifier
+ * @param {String} language : Submission language identifier
+ * @param {String} verdict : Submission's judged verdict
+ * @param {String} executionTime : Submission's execution time
+ * @param {String} memory : memory consumption of the submission
+ * @param {String} timestamp : The time of submission.
+ * @param {Array : Object ({verdict, executionTime, memory, mark})} tests
+ *        			- an array with objects satisfying the given schema
+ * @returns {React.Component} : A <TableRow> containing all nicely-formatted information.
+ */
+
+
+class Submission extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            detailsExpanded : false,
+            anchorRef : React.createRef()
+        }
+    }
+	render() {
+		return (
+            <>
+                <TableRow style={{
+                    backgroundColor: (this.props.verdict==="AC"
+                    || this.props.verdict==="Accepted" ? '#A5D6A7' : '')
+                    // green color if successful
+                }} {...this.props}>
+                    <TableCell>
+                        <ContestantSignature contestantName={this.props.contestant}/>
+                    </TableCell>
+                    <TableCell>
+                        <ProblemSignature problemName={this.props.problem} />
+                    </TableCell>
+                    <TableCell>
+                        <LanguageSignature languageName={this.props.language} />
+                    </TableCell>
+                    <TableCell>
+                        <VerdictSignature verdict={this.props.verdict}/>
+                    </TableCell>
+                    <TableCell>
+                        <ExecTimeSignature time={this.props.executionTime} />
+                    </TableCell>
+                    <TableCell>
+                        <MemorySignature memory={this.props.memory} />
+                    </TableCell>
+                    <TableCell>
+                        <TimestampSignature time={this.props.timestamp} />
+                    </TableCell>
+                </TableRow>
+            </>
+		)
+	}
+}
+
+export default Submission;

--- a/src/submissions/submissionDetail/detailedSubmission.js
+++ b/src/submissions/submissionDetail/detailedSubmission.js
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { Drawer, CardContent, CardHeader, IconButton, Paper, Table, TableHead, TableCell, TableRow, TableBody, Divider } from '@material-ui/core';
+import AccountCircle from '@material-ui/icons/AccountCircle';
+
+import ResultTable from './testBasedVerdictTable.js';
+import VerdictSignature from '../signature/verdictSignature';
+
+/**
+ * @name DetailedSubmission 
+ * @desc Fully-detailed report for a submission. ALL PROPS ARE PASSED DOWN TO <Dialog />
+ * @param (Same requirements as for a <Submission />)
+ * @returns {React.Component} A <Dialog /> component
+ */
+
+class DetailedSubmission extends React.Component {
+    render() {
+        return (
+            <Drawer anchor="right" {...this.props}>
+                <Paper>
+                    <CardHeader avatar={<AccountCircle />}
+                        title={this.props.contestant}
+                        subheader={'Submitted : ' + this.props.timestamp}
+                        action={
+                            <IconButton disabled>
+                                <VerdictSignature verdict={this.props.verdict} reversed />
+                            </IconButton>
+                        } />
+                </Paper>
+                <CardContent>
+                    <Table>
+                        <TableHead>
+                            <TableCell>Language</TableCell>
+                            <TableCell>Problem</TableCell>
+                        </TableHead>
+                        <TableBody>
+                            <TableRow>
+                                <TableCell>{this.props.language}</TableCell>
+                                <TableCell>{this.props.problem}</TableCell>
+                            </TableRow>
+                        </TableBody>
+                    </Table>
+                    <Divider />
+                    <ResultTable tests={this.props.tests} />
+                </CardContent>
+            </Drawer>
+        )
+    }
+}
+
+export default DetailedSubmission;

--- a/src/submissions/submissionDetail/detailedSubmission.js
+++ b/src/submissions/submissionDetail/detailedSubmission.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Drawer, CardContent, CardHeader, IconButton, Paper, Table, TableHead, TableCell, TableRow, TableBody, Divider } from '@material-ui/core';
 import AccountCircle from '@material-ui/icons/AccountCircle';
+import ExitToApp from '@material-ui/icons/ExitToApp';
 
 import ResultTable from './testBasedVerdictTable.js';
 import VerdictSignature from '../signature/verdictSignature';
@@ -16,15 +17,22 @@ import VerdictSignature from '../signature/verdictSignature';
 class DetailedSubmission extends React.Component {
     render() {
         return (
-            <Drawer anchor="right" {...this.props}>
+            <Drawer anchor="right" {...this.props} PaperProps={{
+                style : {margin : 0, overflowX: 'hidden'}
+            }} >
                 <Paper>
                     <CardHeader avatar={<AccountCircle />}
                         title={this.props.contestant}
                         subheader={'Submitted : ' + this.props.timestamp}
                         action={
-                            <IconButton disabled>
-                                <VerdictSignature verdict={this.props.verdict} reversed />
-                            </IconButton>
+                            <>
+                                <IconButton disabled style={{ marginTop: 10, marginRight: 0, paddingRight: 0 }}>
+                                    <VerdictSignature verdict={this.props.verdict} reversed />
+                                </IconButton>
+                                <IconButton onClick={this.props.onClose}>
+                                    <ExitToApp />
+                                </IconButton>
+                            </>
                         } />
                 </Paper>
                 <CardContent>

--- a/src/submissions/submissionDetail/testBasedVerdictTable.js
+++ b/src/submissions/submissionDetail/testBasedVerdictTable.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Table, TableHead, TableCell, TableRow, TableBody } from '@material-ui/core';
+import MemorySignature from '../signature/memorySignature';
+import ExecTimeSignature from '../signature/execTimeSignature';
+import VerdictSignature from '../signature/verdictSignature';
+
+/**
+ * @name AttestationSampleResult
+ * @desc A <TableRow /> respresenting a test case used during judgement
+ * @param {String} verdict : verdict after assessment
+ * @param {String} executionTime : duration of execution
+ * @param {String} memory : memory consumption during execution
+ * @param {String} mark : points awarded
+ * @return {React.Component} a <TableRow /> representing a test
+ */
+
+class AttestationSampleResult extends React.Component {
+    render() {
+        return (
+            <TableRow>
+                <TableCell>
+                    <VerdictSignature verdict={this.props.verdict} />
+                </TableCell>
+                <TableCell>
+                    <ExecTimeSignature time={this.props.executionTime} />
+                </TableCell>
+                <TableCell>
+                    <MemorySignature memory={this.props.memory}/>
+                </TableCell>
+                <TableCell>
+                    {this.props.mark}
+                </TableCell>
+            </TableRow>
+        )
+    }
+}
+
+/**
+ * @name ResultTable
+ * @desc A table showing test-based results for OI problems.
+ * @param {Array : Object ({verdict, executionTime, memory, mark})} tests
+ *        - an array with objects satisfying the given schema
+ * @returns {React.Component} a <Table />
+ */
+
+class ResultTable extends React.Component {
+    render() {
+        if (this.props.tests // check if undefined or null
+            &&
+            this.props.tests.constructor === Array && this.props.tests.length !== 0)
+        // if valid, render normally
+            return (
+                <Table>
+                    <TableHead>
+                        <TableCell>
+                            Verdict
+                        </TableCell>
+                        <TableCell>
+                            Execution duration
+                        </TableCell>
+                        <TableCell>
+                            Memory consumed
+                        </TableCell>
+                        <TableCell>
+                            Points awarded
+                        </TableCell>
+                    </TableHead>
+                    <TableBody>
+                        {this.props.tests.map(test => {
+                            return <AttestationSampleResult {...test} />
+                        })}
+                    </TableBody>
+                </Table>
+            )
+        // else if an empty array or invalid variable type was supplied, assume ACM problem
+            return (<></>)
+    }
+}
+
+export default ResultTable;

--- a/src/submissions/submissionDetail/testBasedVerdictTable.js
+++ b/src/submissions/submissionDetail/testBasedVerdictTable.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table, TableHead, TableCell, TableRow, TableBody } from '@material-ui/core';
+import { Table, TableHead, TableCell, TableRow, TableBody, Typography, CardContent } from '@material-ui/core';
 import MemorySignature from '../signature/memorySignature';
 import ExecTimeSignature from '../signature/execTimeSignature';
 import VerdictSignature from '../signature/verdictSignature';
@@ -73,7 +73,16 @@ class ResultTable extends React.Component {
                 </Table>
             )
         // else if an empty array or invalid variable type was supplied, assume ACM problem
-            return (<></>)
+            return (
+                <CardContent>
+                    <Typography variant="h6">
+                        No test-based judgement details available.
+                    </Typography>
+                    <Typography component="p">
+                        I guess this is an ACM problem?
+                    </Typography>
+                </CardContent>
+            )
     }
 }
 

--- a/src/submissions/submissionLauncher.js
+++ b/src/submissions/submissionLauncher.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { ListItemIcon, ListItemText } from '@material-ui/core';
+import Send from '@material-ui/icons/Send';
+
+/**
+ * @name SubmissionLauncher
+ * @description Element to be rendered in the sidenav, responsible for launching submission table
+ */
+
+class SubmissionLauncher extends React.Component {
+    render() {
+        return (
+            <>
+                <ListItemIcon>
+                    <Send />
+                </ListItemIcon>
+                <ListItemText>
+                    Submissions
+                </ListItemText>
+            </>
+        )
+    }
+}
+
+export default SubmissionLauncher;

--- a/src/submissions/submissionTable.js
+++ b/src/submissions/submissionTable.js
@@ -1,66 +1,15 @@
 import React from "react";
-import { Table, TableBody, TableCell, TableRow, TableHead, Paper, TableSortLabel } from "@material-ui/core";
+import { Table, TableBody, TableCell, TableHead, Paper, TableSortLabel, } from "@material-ui/core";
 
-import ContestantSignature from './signature/contestantSignature.js';
-import ProblemSignature from './signature/problemSignature.js';
-import LanguageSignature from './signature/languageSignature.js';
-import VerdictSignature from './signature/verdictSignature.js';
-import ExecTimeSignature from './signature/execTimeSignature.js';
-import TimestampSignature from './signature/timestampSignature.js';
-import MemorySignature from './signature/memorySignature.js';
-
-/**
- * @name Submission
- * @desc Render a submission table row
- * @param {String} contestant : Contestant identifier
- * @param {String} problem : Problem identifier
- * @param {String} language : Submission language identifier
- * @param {String} verdict : Submission's judged verdict
- * @param {String} executionTime : Submission's execution time
- * @param {String} memory : memory consumption of the submission
- * @param {String} timestamp : The time of submission.
- * @returns {React.Component} : A <TableRow> containing all nicely-formatted information.
- */
-
-
-class Submission extends React.Component {
-	render() {
-		return (
-			<TableRow style={{
-				backgroundColor: (this.props.verdict==="AC"
-				|| this.props.verdict==="Accepted" ? '#A5D6A7' : '')
-			}} button onClick={() => alert(1)}>
-				<TableCell>
-					<ContestantSignature contestantName={this.props.contestant}/>
-				</TableCell>
-				<TableCell>
-					<ProblemSignature problemName={this.props.problem} />
-				</TableCell>
-				<TableCell>
-					<LanguageSignature languageName={this.props.language} />
-				</TableCell>
-				<TableCell>
-					<VerdictSignature verdict={this.props.verdict}/>
-				</TableCell>
-				<TableCell>
-					<ExecTimeSignature time={this.props.executionTime} />
-				</TableCell>
-				<TableCell>
-					<MemorySignature memory={this.props.memory} />
-				</TableCell>
-				<TableCell>
-					<TimestampSignature time={this.props.timestamp} />
-				</TableCell>
-			</TableRow>
-		)
-	}
-}
+import Submission from './submission.js';
+import DetailedSubmission from './submissionDetail/detailedSubmission';
 
 /**
  * @name SubmissionTable
- * @param {Array} SubmissionList : An array containing objects satisfying this schema : 
- * 					{contestant, Problem, Language, Verdict, ExecutionTime, memory, SubmissionTimestamp}
- * @return {Table} : a <Table> containing submissions
+ * @param {Array : Object({contestant, Problem, Language, Verdict, ExecutionTime, memory, timestamp, test})} SubmissionList : An array containing objects satisfying this schema : 
+ * 					{contestant, Problem, Language, Verdict, ExecutionTime, memory, timestamp, test}. All props are strings.
+ * 					except "tests" which is an {Array : Object ({verdict, executionTime, memory, mark})}
+ * @return {Table} : a <Table /> containing submissions
  */
 
 /**
@@ -70,7 +19,11 @@ class Submission extends React.Component {
 	<SubmissionTable submissionList={[{
 		contestant : 'minhducsun123456', problem : 'A',
 		verdict : 'Accepted', executionTime: '00:00:123', memory : '1TB', timestamp: '00:00:00',
-		language : 'Perl',
+		language : 'Perl', tests : [
+			{verdict : 'AC', executionTime : '1000h', memory : '1TB', mark : '30'},
+			{verdict : 'AC', executionTime : '1000d', memory : '1MB', mark : '50'},
+			{verdict : 'AC', executionTime : '0.1s', memory : '5TB', mark : '300'}
+		]
 	},{
 		contestant : 'minhducsun2002', problem : 'A',
 		verdict : 'Wrong output', executionTime: '11:00:234', memory : '1TB', timestamp: '00:00:00',
@@ -78,7 +31,9 @@ class Submission extends React.Component {
 	},{
 		contestant : 'minhducsun123456', problem : 'A',
 		verdict : 'Accepted', executionTime: '38:46:115', memory : '1TB', timestamp: '00:00:00',
-		language : 'C99',
+		language : 'C99', tests : [
+			{verdict : 'AC', executionTime : '5s', memory : '10TB', mark : '30'}
+		]
 	}]}/>
 */
 
@@ -87,7 +42,10 @@ class SubmissionTable extends React.Component {
 		super(props);
 		this.state = {
 			submissionList : this.props.submissionList,
-			reverseSort : true
+			reverseSort : true,
+
+			details : undefined,
+			detailExtendedOpen : false
 		}
 		// Yeah, in order to support sorting
 		// and since props are immutable
@@ -115,61 +73,72 @@ class SubmissionTable extends React.Component {
 
 	render() {
 		return (
-			<Paper>
-				<Table>
-					<TableHead>
-						<TableCell>
-							<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
-								active onClick={() => this.sortBy("contestant")}>
-								Submitted by
-							</TableSortLabel>
-						</TableCell>
-						<TableCell>
-							<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
-								active onClick={() => this.sortBy("problem")}>
-								Problem
-							</TableSortLabel>
-						</TableCell>
-						<TableCell>
-							<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
-								active onClick={() => this.sortBy("language")}>
-								Programming language
-							</TableSortLabel>
-						</TableCell>
-						<TableCell>
-							<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
-								active onClick={() => this.sortBy("verdict")}>
-								Verdict
-							</TableSortLabel>
-						</TableCell>
-						<TableCell>
-							<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
-								active onClick={() => this.sortBy("executionTime")}>
-								Execution duration
-							</TableSortLabel>
-						</TableCell>
-						<TableCell>
-							<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
-								active onClick={() => this.sortBy("memory")}>
-								Memory consumed
-							</TableSortLabel>
-						</TableCell>
-						<TableCell>
-							<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
-								active onClick={() => this.sortBy("timestamp")}>
-								Timestamp
-							</TableSortLabel>
-						</TableCell>
-					</TableHead>
-					<TableBody>
-						{this.state.submissionList.map(submission => {
-							return (
-								<Submission {...submission}/>
-							);
-						})}
-					</TableBody>
-				</Table>
-			</Paper>
+			<>
+				<Paper>
+					<Table>
+						<TableHead>
+							<TableCell>
+								<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
+									active onClick={() => this.sortBy("contestant")}>
+									Submitted by
+								</TableSortLabel>
+							</TableCell>
+							<TableCell>
+								<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
+									active onClick={() => this.sortBy("problem")}>
+									Problem
+								</TableSortLabel>
+							</TableCell>
+							<TableCell>
+								<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
+									active onClick={() => this.sortBy("language")}>
+									Programming language
+								</TableSortLabel>
+							</TableCell>
+							<TableCell>
+								<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
+									active onClick={() => this.sortBy("verdict")}>
+									Verdict
+								</TableSortLabel>
+							</TableCell>
+							<TableCell>
+								<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
+									active onClick={() => this.sortBy("executionTime")}>
+									Execution duration
+								</TableSortLabel>
+							</TableCell>
+							<TableCell>
+								<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
+									active onClick={() => this.sortBy("memory")}>
+									Memory consumed
+								</TableSortLabel>
+							</TableCell>
+							<TableCell>
+								<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
+									active onClick={() => this.sortBy("timestamp")}>
+									Timestamp
+								</TableSortLabel>
+							</TableCell>
+						</TableHead>
+						<TableBody>
+							{this.state.submissionList.map(submission => {
+								return (
+									<Submission {...submission} onClick={() => this.setState({
+										details : {...submission},
+										detailExtendedOpen : true
+									})}/>
+								);
+							})}
+						</TableBody>
+					</Table>
+					{/* a global dialog to avoid re-rendering components */}
+					<DetailedSubmission {...this.state.details}
+						open={this.state.detailExtendedOpen && this.state.details}
+						onClose={() => this.setState({
+							detailExtendedOpen : false
+						})}/>
+				</Paper>
+			</>
 		);
 	}
 }

--- a/src/submissions/submissionTable.js
+++ b/src/submissions/submissionTable.js
@@ -17,7 +17,7 @@ import MemorySignature from './signature/memorySignature.js';
  * @param {String} language : Submission language identifier
  * @param {String} verdict : Submission's judged verdict
  * @param {String} executionTime : Submission's execution time
- * @param {String} memload : memory consumption of the submission
+ * @param {String} memory : memory consumption of the submission
  * @param {String} timestamp : The time of submission.
  * @returns {React.Component} : A <TableRow> containing all nicely-formatted information.
  */
@@ -29,7 +29,7 @@ class Submission extends React.Component {
 			<TableRow style={{
 				backgroundColor: (this.props.verdict==="AC"
 				|| this.props.verdict==="Accepted" ? '#A5D6A7' : '')
-			}}>
+			}} button onClick={() => alert(1)}>
 				<TableCell>
 					<ContestantSignature contestantName={this.props.contestant}/>
 				</TableCell>
@@ -46,7 +46,7 @@ class Submission extends React.Component {
 					<ExecTimeSignature time={this.props.executionTime} />
 				</TableCell>
 				<TableCell>
-					<MemorySignature memload={this.props.memload} />
+					<MemorySignature memory={this.props.memory} />
 				</TableCell>
 				<TableCell>
 					<TimestampSignature time={this.props.timestamp} />
@@ -69,15 +69,15 @@ class Submission extends React.Component {
 /*
 	<SubmissionTable submissionList={[{
 		contestant : 'minhducsun123456', problem : 'A',
-		verdict : 'Accepted', executionTime: '00:00:123', memory : '1TB', submissionTimestamp: '00:00:00',
+		verdict : 'Accepted', executionTime: '00:00:123', memory : '1TB', timestamp: '00:00:00',
 		language : 'Perl',
 	},{
 		contestant : 'minhducsun2002', problem : 'A',
-		verdict : 'Wrong output', executionTime: '11:00:234', memory : '1TB', submissionTimestamp: '00:00:00',
+		verdict : 'Wrong output', executionTime: '11:00:234', memory : '1TB', timestamp: '00:00:00',
 		language : 'Pascal',
 	},{
 		contestant : 'minhducsun123456', problem : 'A',
-		verdict : 'Accepted', executionTime: '38:46:115', memory : '1TB', submissionTimestamp: '00:00:00',
+		verdict : 'Accepted', executionTime: '38:46:115', memory : '1TB', timestamp: '00:00:00',
 		language : 'C99',
 	}]}/>
 */
@@ -145,7 +145,7 @@ class SubmissionTable extends React.Component {
 						<TableCell>
 							<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
 								active onClick={() => this.sortBy("executionTime")}>
-								Verdict
+								Execution duration
 							</TableSortLabel>
 						</TableCell>
 						<TableCell>
@@ -156,7 +156,7 @@ class SubmissionTable extends React.Component {
 						</TableCell>
 						<TableCell>
 							<TableSortLabel direction={this.state.reverseSort ? "desc" : "asc"}
-								active onClick={() => this.sortBy("submissionTimestamp")}>
+								active onClick={() => this.sortBy("timestamp")}>
 								Timestamp
 							</TableSortLabel>
 						</TableCell>
@@ -164,10 +164,7 @@ class SubmissionTable extends React.Component {
 					<TableBody>
 						{this.state.submissionList.map(submission => {
 							return (
-								<Submission contestant={submission.contestant} problem={submission.problem}
-								language={submission.language} verdict={submission.verdict}
-								executionTime={submission.executionTime} memload={submission.memory}
-								timestamp={submission.submissionTimestamp}/>
+								<Submission {...submission}/>
 							);
 						})}
 					</TableBody>


### PR DESCRIPTION
* Sidenav is now possible to launch the submission table
* Adding drawer to show submission's full details 
* Adding icon for unknown verdict
* `<VerdictSignature />` now supports `iconOnly` and reversed display order (text-icon or icon-text, configurable)
* Tests in `index.js` updated to reflect component changes