### PR TITLE
[Async](stub/login.js) : Fetch userId right after logging in

### DIFF
--- a/src/app/globalStatusBar/login/stub/credential.js
+++ b/src/app/globalStatusBar/login/stub/credential.js
@@ -26,7 +26,10 @@ async function verifyLogin(func) {
                 console.log(err)
             }
         })
-        .then(func)
+        .then(() => {
+            if (typeof func === 'function')
+                func();
+        })
 }
 
 export default verifyLogin

--- a/src/app/globalStatusBar/login/stub/login.js
+++ b/src/app/globalStatusBar/login/stub/login.js
@@ -1,3 +1,5 @@
+import verifyLogin from './credential.js'
+
 /**
  * @name constructRequestBody
  * @desc Create an URLSearchParam object suitable to be sent as log in request
@@ -38,10 +40,11 @@ async function login(username, password, func) {
         )
             .then(res => {
                 window.hestia.user.loggedIn = res.ok
-                window.hestia.user.userId = res.json()['_id']
             })
             .then(() => (window.hestia.user.username = username))
             // set username
+            .then(verifyLogin)
+            // get userId 
             .then(func)
     )
     // execute callback

--- a/src/app/globalStatusBar/login/stub/login.js
+++ b/src/app/globalStatusBar/login/stub/login.js
@@ -20,7 +20,7 @@ function constructRequestBody(username, password) {
  * @desc Log in function. On completion, window.hestia.loggedIn will have the result of the log in attempt
  * @param {String} username - Username
  * @param {String} password - Password
- * @param {Function} func - Function to call when window.hestia.updateLoginState returned.
+ * @param {Function} func - Function to call when the global object has been populated with usable value
  * @return {Promise} - a Promise that resolves to the return value of func()
  * @author minhducsun2002
  */
@@ -40,12 +40,15 @@ async function login(username, password, func) {
         )
             .then(res => {
                 window.hestia.user.loggedIn = res.ok
+                window.hestia.user.username = username
+                // set username
             })
-            .then(() => (window.hestia.user.username = username))
-            // set username
             .then(verifyLogin)
             // get userId 
-            .then(func)
+            .then(() => {
+                if (typeof func === 'function')
+                    func()
+            })
             .catch(err => {})
     )
     // execute callback

--- a/src/app/globalStatusBar/login/stub/login.js
+++ b/src/app/globalStatusBar/login/stub/login.js
@@ -49,7 +49,7 @@ async function login(username, password, func) {
                 if (typeof func === 'function')
                     func()
             })
-            .catch(err => {})
+            .catch(err => console.log(err))
     )
     // execute callback
 }

--- a/src/app/globalStatusBar/login/stub/login.js
+++ b/src/app/globalStatusBar/login/stub/login.js
@@ -46,6 +46,7 @@ async function login(username, password, func) {
             .then(verifyLogin)
             // get userId 
             .then(func)
+            .catch(err => {})
     )
     // execute callback
 }


### PR DESCRIPTION
A separate call to `/api/users` is needed to get the necessary parameters for changing password - namely, `userId`.

Also, `login()` no longer throw errors ~during JSON-parsing the `OK` text~ as the call to parse the `OK` text has been removed.

This resolves #59.