### PR TITLE
Upload more stability

### DIFF
--- a/src/app/problemList/codeEditor/codeBox.js
+++ b/src/app/problemList/codeEditor/codeBox.js
@@ -10,6 +10,8 @@ import { pushNotification } from '../../notifier/notify.js'
 
 var reader = new FileReader();
 
+const byte_limit = 15 * 1024;
+
 class CodeBox extends React.PureComponent {
     constructor(props) {
         super(props)
@@ -34,7 +36,7 @@ class CodeBox extends React.PureComponent {
         if (!(file instanceof Blob) && !(file instanceof File))
             // non-File input, hmm..
             return;
-        if (file.size >= 15 * 1024)
+        if (file.size >= byte_limit)
             // 15 KiB limit
             return pushNotification('You tried to upload something too large!')
         reader.onload = () => {
@@ -98,7 +100,11 @@ class CodeBox extends React.PureComponent {
                         <CodeEditor
                             readOnly={this.state.submitting || this.state.fileLoading}
                             ext={this.props.ext[this.state.langId]}
-                            update={(code) => this.setState({ code: code })}
+                            update={(code) => {
+                                if (code.length <= byte_limit)
+                                    this.setState({ code: code })
+                                // enforce source limit even for editor
+                            }}
                             code={this.state.code}
                         />
                 </div>

--- a/src/app/problemList/codeEditor/codeBox.js
+++ b/src/app/problemList/codeEditor/codeBox.js
@@ -38,7 +38,7 @@ class CodeBox extends React.PureComponent {
                 fileLoading: false
             })
         };
-        reader.onloadstart = () => this.setState({ fileLoading: true });
+        this.setState({ fileLoading: true });
         reader.readAsText(file);
     }
 

--- a/src/app/problemList/codeEditor/codeBox.js
+++ b/src/app/problemList/codeEditor/codeBox.js
@@ -6,6 +6,8 @@ import SubmitButton from './submitButton.js'
 import LangSelection from './langSelection.js'
 import UploadButton from './uploadButton.js';
 
+import { pushNotification } from '../../notifier/notify.js'
+
 var reader = new FileReader();
 
 class CodeBox extends React.PureComponent {
@@ -32,6 +34,9 @@ class CodeBox extends React.PureComponent {
         if (!(file instanceof Blob) && !(file instanceof File))
             // non-File input, hmm..
             return;
+        if (file.size >= 15 * 1024)
+            // 15 KiB limit
+            return pushNotification('You tried to upload something too large!')
         reader.onload = () => {
             this.setState({
                 code : reader.result,


### PR DESCRIPTION
Closes #114.

About the issues, I'll give out specific answers here:
- `CircularProgress` not displaying varied lengths: Merely a cosmetic issue though - the idea stays the same, when it is loading, it rolls. Ignored.
- Lags happen when browsing a large file: I imposed a limit on loaded file - `15` `KiB`.
- > When loading large file, changing tab then switch back to Hestia will cause the whole page to be empty. There could be chance that Chrome said "Aw, Snap!"
  - Same as above.
- Upload button still allows uploading even though the previous operation didn't finished yet : 9234b98bbdbdbc723342d0ff38e6247ddf1e7d18 changed the execution flow a little, hopefully it will get fixed.

About the binary thingy... it turns out to be more complicated, I suppose. Checking for non-printable/non-text bytes doesn't seem to work with low false-positive rate, especially when some programming languages allow localized characters. Our best bet would be with MIME types and magic numbers, but it will take **more** effort and seems to be not worthy at this time, especially when there are more important things to do ahead.